### PR TITLE
mkPackages & profiles restructuring

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,14 +22,13 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
-    nixos-hardware.url = "github:NixOS/nixos-hardware/master";
-    impermanence.url = "github:nix-community/impermanence";
     agenix = {
       url = "github:ryantm/agenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    nixos-hardware.url = "github:NixOS/nixos-hardware/master";
+    impermanence.url = "github:nix-community/impermanence";
     nur.url = "github:nix-community/NUR";
 
     arkenfox-user-js = {
@@ -40,9 +39,16 @@
 
   outputs = { self, nixpkgs, ... }@inputs:
     let
-      inherit (lib.tensorfiles.modules) mapModules mkPkgs mkHost;
+      inherit (lib.tensorfiles.modules) mapModules mkPackages mkHost;
 
+      # These assignments are optional and only serve to change the default values
+      # (that being `root` and `./secrets` -- if you don't plan on using any secrets
+      # backend you can simply ignore this), meaning that
+      # you can change or even delete them, however, the projectRoot variable is
+      # required, so please keep that one.
       user = "tsandrini";
+      projectPath = ./.;
+      secretsPath = (projectPath + "/secrets");
 
       lib = nixpkgs.lib.extend (self: super: {
         tensorfiles = import ./lib {
@@ -57,10 +63,7 @@
 
       overlays = mapModules ./overlays import;
 
-      packages = lib.genAttrs [ "x86_64-linux" ] (system:
-        let systemPkgs = mkPkgs nixpkgs system [ ];
-        in mapModules ./pkgs
-        (p: systemPkgs.callPackage p { inherit lib inputs; }));
+      packages = mkPackages ./pkgs { };
 
       nixosModules = mapModules ./modules import;
 

--- a/hosts/spinorbundle/default.nix
+++ b/hosts/spinorbundle/default.nix
@@ -21,13 +21,9 @@
   # --------------------------
   # | ROLES & MODULES & etc. |
   # --------------------------
-  imports = with inputs.self; [
-    ./hardware-configuration.nix
-    nixosModules.profiles.base
-    inputs.home-manager.nixosModules.home-manager
-  ];
+  imports = [ ./hardware-configuration.nix ];
 
-  tensorfiles.profiles.base.enable = true;
+  tensorfiles.profiles.laptop.enable = true;
 
   # ------------------------------
   # | ADDITIONAL SYSTEM PACKAGES |

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -12,9 +12,10 @@
 # 888   88888888 888  888 "Y8888b. 888  888 888     888    888 888 88888888 "Y8888b.
 # Y88b. Y8b.     888  888      X88 Y88..88P 888     888    888 888 Y8b.          X88
 #  "Y888 "Y8888  888  888  88888P'  "Y88P"  888     888    888 888  "Y8888   88888P'
-{ pkgs, lib, self, inputs, user ? "root", ... }:
+{ pkgs, lib, self, inputs, projectPath ? ./..
+, secretsPath ? (projectPath + "/secrets"), user ? "root", ... }:
 let
-  inherit (self.attrsets) mapFilterAttrs;
+  inherit (self.attrsets) mapFilterAttrs mergeAttrs groupAttrsetBySublistElems;
   inherit (self.strings) dirnameFromPath;
 in with lib;
 with builtins; rec {
@@ -84,20 +85,20 @@ with builtins; rec {
   /* Custom nixpkgs constructor. Its purpose is to import provided nixpkgs
      while setting the target platform and all over the needed overlays.
 
-     *Type*: `mkPkgs :: AttrSet -> String -> [(AttrSet -> AttrSet -> AttrSet)] -> Attrset`
+     *Type*: `mkNixpkgs :: AttrSet -> String -> [(AttrSet -> AttrSet -> AttrSet)] -> Attrset`
 
      Example:
      ```nix title="Example" linenums="1"
-     mkPkgs <nixpkgs> "x86_64-linux" []
+     mkNixpkgs <nixpkgs> "x86_64-linux" []
        => { ... }
 
-     mkPkgs inputs.nixpkgs "aarch64-linux" [ (final: prev: {
+     mkNixpkgs inputs.nixpkgs "aarch64-linux" [ (final: prev: {
        customPkgs = inputs.customPkgs { pkgs = final; };
      }) ]
        => { ... }
      ```
   */
-  mkPkgs =
+  mkNixpkgs =
     # (AttrSet) TODO (this is probably not an actual attrset?)
     pkgs:
     # (String) System string identifier (eg: "x86_64-linux", "aarch64-linux", "aarch64-darwin")
@@ -114,7 +115,7 @@ with builtins; rec {
         nurOverlay = final: prev: {
           nur = import inputs.nur { pkgs = final; };
         };
-      in [ pkgsOverlay ] ++ (optional (inputs ? nur) nurOverlay)
+      in [ pkgsOverlay ] ++ (optional (hasAttr "nur" inputs) nurOverlay)
       ++ (attrValues inputs.self.overlays) ++ extraOverlays;
     };
 
@@ -143,7 +144,7 @@ with builtins; rec {
     let
       name = dirnameFromPath dir;
       system = removeSuffix "\n" (readFile "${dir}/system");
-      systemPkgs = mkPkgs inputs.nixpkgs system [ ];
+      systemPkgs = mkNixpkgs inputs.nixpkgs system [ ];
     in nixosSystem {
       inherit system;
       pkgs = systemPkgs;
@@ -160,4 +161,123 @@ with builtins; rec {
         (dir)
       ];
     };
+
+  /* Given a filepath, it will try to parse a list of platforms from the
+     header (first line) of the provided file in the following format
+
+     ```nix linenums="1"
+     # platforms: aarch64-linux, x86_64-linux
+     # rest of the file ...
+     # ...
+     ```
+
+     In case that the provided file doesn't containt any platform specification
+     it will simply return an empty list.
+
+     *Type*: `parsePlatformHeader :: Path -> [String]`
+
+     Example:
+     ```nix title="Example" linenums="1"
+     parsePlatformHeader example-file.nix
+       => [ "aarch64-linux" "x86_64-linux" ]
+     ```
+  */
+  parsePlatformHeader =
+    # (Path) Path to the file whose platform header should be parsed
+    file:
+    let
+      fileContent = readFile file;
+      lines = splitString "\n" fileContent;
+      header = replaceStrings [ " " ] [ "" ] (head lines);
+    in (if (hasPrefix "#platforms:" header) then
+      splitString "," (removePrefix "#platforms:" header)
+    else
+      [ ]);
+
+  /* Returns a dummy derivation with a given name as and a platform
+     specific builder. Useful when constructing certain defaults or general
+     debugging. The resulting derivation can be compiled without errors, but
+     obviously doesn't produce any nontrivial output.
+
+     *Type*: `mkDummyDerivation :: String -> String -> AttrSet a -> Package a`
+
+     Example:
+     ```nix title="Example" linenums="1"
+     mkDummyDerivation "example-pkg" "aarch64-linux" {}
+      => <derivation ....>
+
+     mkDummyDerivation "example-pkg2" "x86_64-linux" { meta.license = lib.licenses.gpl20; }
+      => <derivation ....>
+
+     mkDummyDerivation "example-pkg3" "x86_64-linux" { installPhase = "mkdir -p $out && touch $out/hey"; }
+      => <derivation ....>
+     ```
+  */
+  mkDummyDerivation =
+    # (String) Name of the dummy derivation
+    name:
+    # (String) System architecture string. This is going to be used for choosing the target derivation builder
+    system:
+    # (AttrSet a) An attrset with possibily any additional values that are going to be passed to the mkDerivation call
+    extraArgs:
+    let
+      systemPkgs = mkNixpkgs inputs.nixpkgs system [ ];
+      args = rec {
+        inherit name;
+        version = "not-for-build";
+
+        # In case something tries to actually evaluate this, we have to provide
+        #
+        # 1. Declaratively some source?
+        # 2. Minimally something to do during the installPhase
+        src = ./.;
+        dontBuild = true;
+        installPhase = ''
+          echo "DUMMY PACKAGE for ${name}" && mkdir -p $out
+        '';
+
+        meta = {
+          homepage = "https://github.com/tsandrini/tensorfiles";
+          description = "Dummy package used for ${name} -- not for build";
+          license = licenses.mit;
+          platforms = [ system ];
+          maintainers = [ ];
+        };
+      } // extraArgs;
+    in systemPkgs.stdenv.mkDerivation args;
+
+  /* Custom `packages` flake output constructor.
+     It recursively traverses the provided root directory and scans for packages.
+     The resulting attrset is constructed in such a way to comply with the
+     flake `packages` format, that is
+
+     packages."<system>"."<name>"
+
+     The platform package specifications will be parsed from the packages
+     themselves using the `parsePlatformHeader` which reduces the overall
+     amount of manual setup while still maintaining an overall pure
+     declarative structure.
+
+     *Type*: `mkPackages :: Path -> { callPackageExtraAttrs :: AttrSet a; pkgsExtraOverlays :: [ (AttrSet -> AttrSet -> AttrSet) ] } -> AttrSet b`
+  */
+  mkPackages =
+    # (Path) Path to the root dir which should be scanned for packages
+    dir:
+    {
+    # (AttrSet a) Extra arguments that should be inherit for the callPackage pattern
+    callPackageExtraAttrs ? { },
+    # ([(AttrSet -> AttrSet -> AttrSet)]) Extra overlays that should be applied to created the nixpkgs instance
+    pkgsExtraOverlays ? [ ] }:
+    let
+      pkgsByPlatforms = groupAttrsetBySublistElems (mapModules dir (p:
+        parsePlatformHeader
+        (if pathExists "${p}/default.nix" then "${p}/default.nix" else p)));
+      pkgPaths = mapModules dir (p: p);
+    in genAttrs (attrNames pkgsByPlatforms) (system:
+      let
+        systemPkgs = mkNixpkgs inputs.nixpkgs system ([ ] ++ pkgsExtraOverlays);
+      in mergeAttrs (map (p: {
+        "${p}" = systemPkgs.callPackage pkgPaths.${p}
+          ({ inherit lib inputs; } // callPackageExtraAttrs);
+      }) pkgsByPlatforms.${system}));
 }

--- a/modules/profiles/_load-all-modules.nix
+++ b/modules/profiles/_load-all-modules.nix
@@ -1,0 +1,74 @@
+# --- modules/profiles/_load-all-modules.nix
+#
+# Author:  tsandrini <tomas.sandrini@seznam.cz>
+# URL:     https://github.com/tsandrini/tensorfiles
+# License: MIT
+#
+# 888                                                .d888 d8b 888
+# 888                                               d88P"  Y8P 888
+# 888                                               888        888
+# 888888 .d88b.  88888b.  .d8888b   .d88b.  888d888 888888 888 888  .d88b.  .d8888b
+# 888   d8P  Y8b 888 "88b 88K      d88""88b 888P"   888    888 888 d8P  Y8b 88K
+# 888   88888888 888  888 "Y8888b. 888  888 888     888    888 888 88888888 "Y8888b.
+# Y88b. Y8b.     888  888      X88 Y88..88P 888     888    888 888 Y8b.          X88
+#  "Y888 "Y8888  888  888  88888P'  "Y88P"  888     888    888 888  "Y8888   88888P'
+{ lib, inputs, ... }:
+with builtins;
+with lib; {
+  # the purpose of this module is to load all of the defined modules as well
+  # as any possibly needed 3rd party modules.
+  #
+  # note: contrary to usual practices in imperative languages this is actually
+  # the prefered way of handling dependencies between modules since
+  #
+  # 1. nix is a lazily evaluated language
+  # 2. modules are executed only after enabling them via their options (modules
+  #    that are autoenabled by default will be either turned off or simply skipped)
+  #
+  # by doing this, we can create a fully (mostly) importless module ecosystem
+  # which prevents any potential conflicts since everything will be reduced
+  # to overriding attrsets.
+  imports = (with inputs; [
+    impermanence.nixosModules.impermanence
+    home-manager.nixosModules.home-manager
+    agenix.nixosModules.default
+    nur.nixosModules.nur
+  ]) ++ (with inputs.self.nixosModules; [
+    misc.gtk
+    misc.nix
+    misc.xdg
+
+    programs.browsers.firefox
+    programs.dmenu
+    programs.editors.neovim
+    programs.file-managers.lf
+    programs.git
+    programs.newsboat
+    programs.pywal
+    programs.shells.zsh
+    programs.terminals.alacritty
+
+    security.agenix
+
+    services.dunst
+    services.pywalfox-native
+    services.networking.networkmanager
+    services.x11.picom
+    services.x11.redshift
+    services.x11.window-managers.xmonad
+
+    system.persistence
+    system.users
+
+    tasks.nix-garbage-collect
+    tasks.system-autoupgrade
+
+    # profiles
+    profiles.base
+    profiles.headless
+    profiles.minimal
+    profiles.laptop
+  ]);
+
+  meta.maintainers = with tensorfiles.maintainers; [ tsandrini ];
+}

--- a/modules/profiles/headless.nix
+++ b/modules/profiles/headless.nix
@@ -1,4 +1,4 @@
-# --- modules/profiles/base.nix
+# --- modules/profiles/headless.nix
 #
 # Author:  tsandrini <tomas.sandrini@seznam.cz>
 # URL:     https://github.com/tsandrini/tensorfiles
@@ -12,35 +12,35 @@
 # 888   88888888 888  888 "Y8888b. 888  888 888     888    888 888 88888888 "Y8888b.
 # Y88b. Y8b.     888  888      X88 Y88..88P 888     888    888 888 Y8b.          X88
 #  "Y888 "Y8888  888  888  88888P'  "Y88P"  888     888    888 888  "Y8888   88888P'
-{ config, lib, ... }:
+{ config, lib, pkgs, inputs, user ? "root", ... }:
 with builtins;
 with lib;
 let
   inherit (tensorfiles.modules) mkOverrideAtProfileLevel;
 
-  cfg = config.tensorfiles.profiles.base;
+  cfg = config.tensorfiles.profiles.headless;
   _ = mkOverrideAtProfileLevel;
 in {
-  options.tensorfiles.profiles.base = with types;
+  options.tensorfiles.profiles.headless = with types;
     with tensorfiles.options; {
       enable = mkEnableOption (mdDoc ''
-        Enables NixOS module that configures/handles the base system profile.
+        Enables NixOS module that configures/handles the headless system profile.
 
-        **Base layer** sets up necessary structures to be able to simply
-        just evaluate the configuration, ie. not build it, meaning that this layer
-        enables fundamental functionality that other higher level modules rely
-        on.
+        **Headless layer** builds on top of the minimal layer and adds other
+        server-like functionalty like simple shells, basic networking for remote
+        access and simple editors.
       '');
     };
 
   config = mkIf cfg.enable (mkMerge [
     # |----------------------------------------------------------------------| #
     ({
-      system.stateVersion = _ "23.05";
+      tensorfiles.profiles.minimal.enable = _ true;
 
-      tensorfiles.system.users.enable = _ true;
-      tensorfiles.misc.nix.enable = _ true;
-      tensorfiles.misc.xdg.enable = _ true;
+      tensorfiles.programs.editors.neovim.enable = _ true;
+      tensorfiles.programs.git.enable = _ true;
+      tensorfiles.services.networking.networkmanager.enable = _ true;
+      tensorfiles.programs.shells.zsh.enable = _ true;
     })
     # |----------------------------------------------------------------------| #
   ]);

--- a/modules/profiles/laptop.nix
+++ b/modules/profiles/laptop.nix
@@ -1,0 +1,77 @@
+# --- modules/profiles/laptop.nix
+#
+# Author:  tsandrini <tomas.sandrini@seznam.cz>
+# URL:     https://github.com/tsandrini/tensorfiles
+# License: MIT
+#
+# 888                                                .d888 d8b 888
+# 888                                               d88P"  Y8P 888
+# 888                                               888        888
+# 888888 .d88b.  88888b.  .d8888b   .d88b.  888d888 888888 888 888  .d88b.  .d8888b
+# 888   d8P  Y8b 888 "88b 88K      d88""88b 888P"   888    888 888 d8P  Y8b 88K
+# 888   88888888 888  888 "Y8888b. 888  888 888     888    888 888 88888888 "Y8888b.
+# Y88b. Y8b.     888  888      X88 Y88..88P 888     888    888 888 Y8b.          X88
+#  "Y888 "Y8888  888  888  88888P'  "Y88P"  888     888    888 888  "Y8888   88888P'
+{ config, lib, pkgs, inputs, user ? "root", ... }:
+with builtins;
+with lib;
+let
+  inherit (tensorfiles.modules) mkOverrideAtProfileLevel;
+
+  cfg = config.tensorfiles.profiles.laptop;
+  _ = mkOverrideAtProfileLevel;
+in {
+  options.tensorfiles.profiles.laptop = with types;
+    with tensorfiles.options; {
+      enable = mkEnableOption (mdDoc ''
+        Enables NixOS module that configures/handles the laptop system profile.
+
+        **TODO**: decouple this into a graphical + xmonad + persitence profiles
+      '');
+    };
+
+  config = mkIf cfg.enable (mkMerge [
+    # |----------------------------------------------------------------------| #
+    ({
+      tensorfiles.profiles.headless.enable = _ true;
+
+      tensorfiles.misc.gtk.enable = _ true;
+
+      tensorfiles.programs.newsboat.enable = _ true;
+      tensorfiles.programs.dmenu.enable = _ true;
+      tensorfiles.programs.file-managers.lf.enable = _ true;
+      tensorfiles.programs.pywal.enable = _ true;
+      tensorfiles.programs.terminals.alacritty.enable = _ true;
+      tensorfiles.programs.browsers.firefox.enable = _ true;
+
+      tensorfiles.security.agenix.enable = _ true;
+      tensorfiles.services.dunst.enable = _ true;
+
+      tensorfiles.services.pywalfox-native.enable = _ true;
+      tensorfiles.services.x11.picom.enable = _ true;
+      tensorfiles.services.x11.redshift.enable = _ true;
+      tensorfiles.services.x11.window-managers.xmonad.enable = _ true;
+
+      tensorfiles.system.persistence.enable = _ true;
+
+      tensorfiles.system.persistence.btrfsWipe = {
+        enable = _ true;
+        rootPartition = _ "/dev/mapper/enc";
+      };
+
+      # TODO fix this
+      # Init also the root user even if not used elsewhere
+      tensorfiles.system.users.home.settings."root" = { isSudoer = _ false; };
+      tensorfiles.system.users.home.settings."tsandrini" = {
+        isSudoer = _ true;
+        email = _ "tomas.sandrini@seznam.cz";
+      };
+
+      tensorfiles.misc.xdg.home.settings."root" = { };
+      tensorfiles.misc.xdg.home.settings."tsandrini" = { };
+    })
+    # |----------------------------------------------------------------------| #
+  ]);
+
+  meta.maintainers = with tensorfiles.maintainers; [ tsandrini ];
+}

--- a/modules/profiles/minimal.nix
+++ b/modules/profiles/minimal.nix
@@ -1,4 +1,4 @@
-# --- modules/profiles/base.nix
+# --- modules/profiles/minimal.nix
 #
 # Author:  tsandrini <tomas.sandrini@seznam.cz>
 # URL:     https://github.com/tsandrini/tensorfiles
@@ -12,35 +12,61 @@
 # 888   88888888 888  888 "Y8888b. 888  888 888     888    888 888 88888888 "Y8888b.
 # Y88b. Y8b.     888  888      X88 Y88..88P 888     888    888 888 Y8b.          X88
 #  "Y888 "Y8888  888  888  88888P'  "Y88P"  888     888    888 888  "Y8888   88888P'
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 with builtins;
 with lib;
 let
   inherit (tensorfiles.modules) mkOverrideAtProfileLevel;
 
-  cfg = config.tensorfiles.profiles.base;
+  cfg = config.tensorfiles.profiles.minimal;
   _ = mkOverrideAtProfileLevel;
 in {
-  options.tensorfiles.profiles.base = with types;
+  options.tensorfiles.profiles.minimal = with types;
     with tensorfiles.options; {
       enable = mkEnableOption (mdDoc ''
-        Enables NixOS module that configures/handles the base system profile.
+        Enables NixOS module that configures/handles the minimal system profile.
 
-        **Base layer** sets up necessary structures to be able to simply
-        just evaluate the configuration, ie. not build it, meaning that this layer
-        enables fundamental functionality that other higher level modules rely
-        on.
+        **Minimal layers** builds on top of the base layer and creates a
+        minimal bootable system. It isn't targetted to posses any other functionality,
+        for example if you'd like remote access and more of server-like features,
+        use the headless profile that build on top of this one.
       '');
     };
 
   config = mkIf cfg.enable (mkMerge [
     # |----------------------------------------------------------------------| #
     ({
-      system.stateVersion = _ "23.05";
+      tensorfiles.profiles.base.enable = _ true;
 
-      tensorfiles.system.users.enable = _ true;
-      tensorfiles.misc.nix.enable = _ true;
-      tensorfiles.misc.xdg.enable = _ true;
+      tensorfiles.tasks.nix-garbage-collect.enable = _ true;
+      tensorfiles.tasks.system-autoupgrade.enable = _ true;
+
+      time.timeZone = _ "Europe/Prague";
+      i18n.defaultLocale = _ "en_US.UTF-8";
+
+      console = {
+        enable = _ true;
+        useXkbConfig = _ true;
+        font = _ "ter-132n";
+      };
+
+      environment.systemPackages = with pkgs; [
+        # BASE UTILS
+        htop
+        wget
+        curl
+        jq
+        killall
+        openssl
+        vim
+        # HW
+        exfat
+        dosfstools
+        exfatprogs
+        udisks
+        pciutils
+        usbutils
+      ];
     })
     # |----------------------------------------------------------------------| #
   ]);

--- a/modules/system/users.nix
+++ b/modules/system/users.nix
@@ -12,7 +12,8 @@
 # 888   88888888 888  888 "Y8888b. 888  888 888     888    888 888 88888888 "Y8888b.
 # Y88b. Y8b.     888  888      X88 Y88..88P 888     888    888 888 Y8b.          X88
 #  "Y888 "Y8888  888  888  88888P'  "Y88P"  888     888    888 888  "Y8888   88888P'
-{ config, lib, pkgs, inputs, user ? "root", ... }:
+{ config, lib, pkgs, inputs, projectPath
+, secretsPath ? (projectPath + "/secrets"), user ? "root", ... }:
 with builtins;
 with lib;
 let
@@ -280,7 +281,8 @@ in {
     (mkIf (cfg.home.enable && ((isAgenixEnabled config) && cfg.agenix.enable)) {
       age.secrets = mapToAttrsAndMerge (attrNames cfg.home.settings) (_user: {
         "common/passwords/users/${_user}_default" = {
-          file = _ ../../secrets/common/passwords/users/${_user}_default.age;
+          file =
+            _ (secretsPath + "/common/passwords/users/${_user}_default.age");
         };
       });
     })

--- a/pkgs/docs/default.nix
+++ b/pkgs/docs/default.nix
@@ -1,3 +1,4 @@
+# platforms: x86_64-linux, aarch64-linux
 # --- pkgs/docs/default.nix
 #
 # Author:  tsandrini <tomas.sandrini@seznam.cz>

--- a/pkgs/docs/default.nix
+++ b/pkgs/docs/default.nix
@@ -14,17 +14,19 @@
 # Y88b. Y8b.     888  888      X88 Y88..88P 888     888    888 888 Y8b.          X88
 #  "Y888 "Y8888  888  888  88888P'  "Y88P"  888     888    888 888  "Y8888   88888P'
 { lib, pkgs, inputs, stdenv, mkdocs, pandoc, python3, python310Packages
-, runCommand, nixosOptionsDoc, nixdoc, writeText, perl, ... }:
+, runCommand, nixosOptionsDoc, nixdoc, writeText, perl, system, ... }:
 let
   inherit (lib.tensorfiles.attrsets) flatten;
   inherit (lib.tensorfiles.modules) mapModules;
 
   READMEs = let
     readmeToDerivation = path: writeText "README.md" (builtins.readFile path);
+    projectPath = ../../.;
   in {
-    main = readmeToDerivation ../../README.md;
+    main = readmeToDerivation (projectPath + "/README.md");
     hosts = {
-      "spinorbundle" = readmeToDerivation ../../hosts/spinorbundle/README.md;
+      "spinorbundle" =
+        readmeToDerivation (projectPath + "/hosts/spinorbundle/README.md");
     };
   };
 
@@ -130,15 +132,20 @@ let
       ++ (loadModulesInDir ../../modules/services)
       ++ (loadModulesInDir ../../modules/system)
       ++ (loadModulesInDir ../../modules/tasks)
-      ++ (loadModulesInDir ../../modules/security);
-      specialArgs = {
+      ++ (loadModulesInDir ../../modules/security)
+      ++ (loadModulesInDir ../../modules/profiles);
+      specialArgs = rec {
         # TODO: Warning!!!!
         # This is very bad practice and should be usually avoided at all costs,
         # but modules cannot be easily evaluated otherwise. In the future it would
         # be probably best to just create the inputs manually directly here.
-        inherit lib pkgs inputs;
-        user = "root";
-        system = "x86_64-linux";
+        inherit lib pkgs inputs system;
+        lintCompatibility = true;
+        projectPath = ../..;
+        secretsPath = (projectPath + "/secrets");
+        secretsAttrset = { };
+        hostName = "exampleHost";
+        user = "exampleUser";
       };
     };
     optionsDoc = nixosOptionsDoc { inherit (eval) options; };
@@ -189,7 +196,7 @@ in stdenv.mkDerivation {
     homepage = "https://github.com/tsandrini/tensorfiles";
     description = "The combined Documentation of the whole tensorfiles flake.";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
     maintainers = with tensorfiles.maintainers; [ tsandrini ];
   };
 }

--- a/pkgs/pywalfox-native.nix
+++ b/pkgs/pywalfox-native.nix
@@ -1,3 +1,4 @@
+# platforms: x86_64-linux
 # --- pkgs/pywalfox-native.nix
 #
 # Author:  tsandrini <tomas.sandrini@seznam.cz>


### PR DESCRIPTION
# Description

1. **mkPackages**
  Replaced old `genAttrs` based call with a manually set architecture "x86_64-linux" with a modular `mkPackages` call that
  dynamically parses the platform strings, groups all of the resulting packages together and sets up the appropriate flake outputs.
2. **profiles restructuring**
  After some thought and "praxis" I've decided to restructure how I handle the profiles functionality. The old way based on modules
   "importing" was running into issues with duplicit imports and thus duplicit options which could've been resolved using some 
   dynamic importer or logger which I didn't find particularly appealing and "nixy".