### PR TITLE
ci(update-flake-lock): use personal acc instead of bot to run actions

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -16,7 +16,9 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@main
         with:
           pr-reviewers: tsandrini
-          pr-title: "Update flake.lock" # Title of PR to be created
+          pr-assignees: tsandrini
+          pr-title: "Automated action - Update flake.lock" # Title of PR to be created
           pr-labels: | # Labels to be set on the PR
             dependencies
             automated
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
# ci(update-flake-lock): use personal acc instead of bot to run actions

## Description